### PR TITLE
fix: use directory instead of the `.zip` file for artifact path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: screenly-chrome-extension
-          path: screenly-chrome-extension.zip
+          path: artifacts/dist
 
   generate-sbom:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changes

* Used directory for artifact for source path to avoid double compression
* The `.zip` file needed for the attestation step is still there.

### Screenshots

![image](https://github.com/user-attachments/assets/19005b63-4279-47bb-9759-92af7da34f43)
![image](https://github.com/user-attachments/assets/868e2859-68d8-4564-9733-6a252f86cdb4)

### CI Runs and Artifacts

* https://github.com/Screenly/Chrome-Extension/actions/runs/11819542064?pr=28