### PR TITLE
chore(ci): add a workflow step for publishing a new release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,8 +75,6 @@ jobs:
           allowUpdates: true
           prerelease: true
           artifacts: "screenly-chrome-extension-${{ github.ref_name }}.zip"
-          tag: ${{ github.ref_name }}
-          commit: ${{ github.sha }}
 
   generate-sbom:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,11 +63,13 @@ jobs:
 
       - name: Copy Artifact
         run: |
+          ls -l # TODO: Remove.
+          ls -l ${{ github.workspace }} # TODO: Remove.
           cp \
             ${{ github.workspace }}/screenly-chrome-extension.zip \
             ${{ github.workspace }}/screenly-chrome-extension-${{ github.ref_name }}.zip
       - name: Create Release
-        # if: startsWith(github.ref, 'refs/tags/') # TODO: Uncomment after testing.
+        if: startsWith(github.ref, 'refs/tags/')
         uses: ncipollo/release-action@v1.11.2
         with:
           allowUpdates: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,11 +63,11 @@ jobs:
 
       - name: Copy Artifact
         run: |
-          ls -l # TODO: Remove.
           ls -l ${{ github.workspace }} # TODO: Remove.
           cp \
             ${{ github.workspace }}/screenly-chrome-extension.zip \
-            ${{ github.workspace }}/screenly-chrome-extension-${{ github.ref_name }}.zip
+            ${{ github.workspace }}/screenly-chrome-extension-renamed.zip
+          ls -l ${{ github.workspace }} # TODO: Remove.
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: ncipollo/release-action@v1.11.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,13 +61,13 @@ jobs:
           name: screenly-chrome-extension
           path: artifacts/dist
 
-      - name: Copy Artifact
+      - name: Prepare Release
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          ls -l ${{ github.workspace }} # TODO: Remove.
           cp \
             ${{ github.workspace }}/screenly-chrome-extension.zip \
-            ${{ github.workspace }}/screenly-chrome-extension-renamed.zip
-          ls -l ${{ github.workspace }} # TODO: Remove.
+            ${{ github.workspace }}/screenly-chrome-extension-${{ github.ref_name }}.zip
+
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: ncipollo/release-action@v1.11.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,6 +61,21 @@ jobs:
           name: screenly-chrome-extension
           path: artifacts/dist
 
+      - name: Copy Artifact
+        run: |
+          cp \
+            ${{ github.workspace }}/screenly-chrome-extension.zip \
+            ${{ github.workspace }}/screenly-chrome-extension-${{ github.ref_name }}.zip
+      - name: Create Release
+        # if: startsWith(github.ref, 'refs/tags/') # TODO: Uncomment after testing.
+        uses: ncipollo/release-action@v1.11.2
+        with:
+          allowUpdates: true
+          prerelease: true
+          artifacts: "screenly-chrome-extension-${{ github.ref_name }}.zip"
+          tag: ${{ github.ref_name }}
+          commit: ${{ github.sha }}
+
   generate-sbom:
     runs-on: ubuntu-latest
     name: Generate SBOM

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build and Generate Artifact
     permissions:
       id-token: write
-      contents: read
+      contents: write
       attestations: write
     steps:
       - name: Checkout


### PR DESCRIPTION
### Overview

* Fixes #27
* Creates a new step for publishing a release

### References

* https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
* Please see this [CI run](https://github.com/nicomiguelino/devtools/actions/runs/11823148803) from [one of my personal repositories](https://github.com/nicomiguelino/devtools/blob/main/.github/workflows/build.yaml) for proof that the workflow works.