### PR TITLE
fix: bump extension version to 1.2.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,10 @@ jobs:
       - name: Compress
         run: |
           cp artifacts/dist/manifest.json manifest.json
+          echo "USER: $USER"
+          echo "whoami: $(whoami)"
+          ls -l artifacts/dist/
+          ls -l manifest.json
           cat manifest.json | envsubst > artifacts/dist/manifest.json
 
           cd artifacts/dist/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,19 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build Docker images
-        run: |
-          docker compose build
-
-      - name: Run Unit Tests
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/app:delegated \
-            -v /app/node_modules \
-            sce_webpack:latest \
-            /bin/bash -c "npx webpack --config webpack.dev.js && npm run test"
-
       - name: Prepare manifest.json
         run: |
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
@@ -53,6 +40,19 @@ jobs:
           cat manifest.json.template | envsubst > src/manifest.json
           rm manifest.json.template
           cat src/manifest.json
+
+      - name: Build Docker images
+        run: |
+          docker compose build
+
+      - name: Run Unit Tests
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/app:delegated \
+            -v /app/node_modules \
+            sce_webpack:latest \
+            /bin/bash -c "npx webpack --config webpack.dev.js && npm run test"
 
       - name: Build and Package the Extension
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             export SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/v}
           else
-            export SCREENLY_CE_VERSION=$(git describe --tags --abbrev=0)
+            export SCREENLY_CE_VERSION="0.0.0"
           fi
 
           cp src/manifest.json manifest.json.template

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,21 +25,14 @@ jobs:
       - name: Prepare manifest.json
         run: |
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            # echo "SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
             export SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/v}
           else
-            # echo "SCREENLY_CE_VERSION=0.0.0" >> $GITHUB_ENV
-            export SCREENLY_CE_VERSION=0.0.0
+            export SCREENLY_CE_VERSION=$(git describe --tags --abbrev=0)
           fi
-
-          ls -l
-          echo "SCREENLY_CE_VERSION=${SCREENLY_CE_VERSION}"
-          cat src/manifest.json
 
           cp src/manifest.json manifest.json.template
           cat manifest.json.template | envsubst > src/manifest.json
           rm manifest.json.template
-          cat src/manifest.json
 
       - name: Build Docker images
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,15 +45,20 @@ jobs:
             sce_webpack:latest \
             /bin/bash -c "npm run build && cp -r dist/ artifacts/"
 
-      - name: Set SCREENLY_CE_VERSION to tag name.
-        if: startsWith(github.ref, 'refs/tags/')
-        run: echo "SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Prepare Environment Variables
+        run: |
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            echo "SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          else
+            echo "SCREENLY_CE_VERSION=0.0.0" >> $GITHUB_ENV
+          fi
 
       - name: Compress
         run: |
+          cp artifacts/dist/manifest.json manifest.json
+          cat manifest.json | envsubst > artifacts/dist/manifest.json
+
           cd artifacts/dist/
-          SCREENLY_CE_VERSION=${SCREENLY_CE_VERSION:-0.0.0}
-          echo "SCREENLY_CE_VERSION=${SCREENLY_CE_VERSION}"
           zip -r ${{ github.workspace }}/screenly-chrome-extension.zip .
 
       - name: Attest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
             sce_webpack:latest \
             /bin/bash -c "npx webpack --config webpack.dev.js && npm run test"
 
-      - name: Prepare Environment Variables
+      - name: Prepare manifest.json
         run: |
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             # echo "SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
@@ -48,7 +48,7 @@ jobs:
           ls -l
 
           cp src/manifest.json manifest.json.template
-          cat manifest.json | envsubst > src/manifest.json
+          cat manifest.json.template | envsubst > src/manifest.json
           rm manifest.json.template
 
       - name: Build and Package the Extension

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,10 +30,6 @@ jobs:
             export SCREENLY_CE_VERSION="0.0.0"
           fi
 
-          # cp src/manifest.json manifest.json.template
-          # cat manifest.json.template | envsubst > src/manifest.json
-          # rm manifest.json.template
-
           cat <<< $(cat src/manifest.json | jq --arg version "$SCREENLY_CE_VERSION" '.version = $version') > src/manifest.json
 
       - name: Build Docker images

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Compress
         run: |
+          ls -l
+          ls -l artifacts/dist/
           cd artifacts/dist/
           zip -r ${{ github.workspace }}/screenly-chrome-extension.zip .
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
 
           ls -l
           echo "SCREENLY_CE_VERSION=${SCREENLY_CE_VERSION}"
-          cat src/manifest.json | envsubst > src/manifest.json
+          cat src/manifest.json
 
           cp src/manifest.json manifest.json.template
           cat manifest.json.template | envsubst > src/manifest.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,10 +46,13 @@ jobs:
           fi
 
           ls -l
+          echo "SCREENLY_CE_VERSION=${SCREENLY_CE_VERSION}"
+          cat src/manifest.json | envsubst > src/manifest.json
 
           cp src/manifest.json manifest.json.template
           cat manifest.json.template | envsubst > src/manifest.json
           rm manifest.json.template
+          cat src/manifest.json
 
       - name: Build and Package the Extension
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,22 @@ jobs:
             sce_webpack:latest \
             /bin/bash -c "npx webpack --config webpack.dev.js && npm run test"
 
+      - name: Prepare Environment Variables
+        run: |
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            # echo "SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+            export SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            # echo "SCREENLY_CE_VERSION=0.0.0" >> $GITHUB_ENV
+            export SCREENLY_CE_VERSION=0.0.0
+          fi
+
+          ls -l
+
+          cp src/manifest.json manifest.json.template
+          cat manifest.json | envsubst > src/manifest.json
+          rm manifest.json.template
+
       - name: Build and Package the Extension
         run: |
           mkdir artifacts
@@ -45,23 +61,8 @@ jobs:
             sce_webpack:latest \
             /bin/bash -c "npm run build && cp -r dist/ artifacts/"
 
-      - name: Prepare Environment Variables
-        run: |
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            echo "SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-          else
-            echo "SCREENLY_CE_VERSION=0.0.0" >> $GITHUB_ENV
-          fi
-
       - name: Compress
         run: |
-          cp artifacts/dist/manifest.json manifest.json
-          echo "USER: $USER"
-          echo "whoami: $(whoami)"
-          ls -l artifacts/dist/
-          ls -l manifest.json
-          sudo cat manifest.json | envsubst > artifacts/dist/manifest.json
-
           cd artifacts/dist/
           zip -r ${{ github.workspace }}/screenly-chrome-extension.zip .
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
           echo "whoami: $(whoami)"
           ls -l artifacts/dist/
           ls -l manifest.json
-          cat manifest.json | envsubst > artifacts/dist/manifest.json
+          sudo cat manifest.json | envsubst > artifacts/dist/manifest.json
 
           cd artifacts/dist/
           zip -r ${{ github.workspace }}/screenly-chrome-extension.zip .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,9 +30,11 @@ jobs:
             export SCREENLY_CE_VERSION="0.0.0"
           fi
 
-          cp src/manifest.json manifest.json.template
-          cat manifest.json.template | envsubst > src/manifest.json
-          rm manifest.json.template
+          # cp src/manifest.json manifest.json.template
+          # cat manifest.json.template | envsubst > src/manifest.json
+          # rm manifest.json.template
+
+          cat <<< $(cat src/manifest.json | jq --arg version "$SCREENLY_CE_VERSION" '.version = $version') > src/manifest.json
 
       - name: Build Docker images
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,11 +45,15 @@ jobs:
             sce_webpack:latest \
             /bin/bash -c "npm run build && cp -r dist/ artifacts/"
 
+      - name: Set SCREENLY_CE_VERSION to tag name.
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "SCREENLY_CE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
       - name: Compress
         run: |
-          ls -l
-          ls -l artifacts/dist/
           cd artifacts/dist/
+          SCREENLY_CE_VERSION=${SCREENLY_CE_VERSION:-0.0.0}
+          echo "SCREENLY_CE_VERSION=${SCREENLY_CE_VERSION}"
           zip -r ${{ github.workspace }}/screenly-chrome-extension.zip .
 
       - name: Attest

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ _gulp-version
 /dist
 /src/test/tests.html
 node_modules
+
+screenly-chrome-extension-*.zip

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ docker run \
     sce_webpack:latest \
     /bin/bash -c "npx webpack --config webpack.prod.js"
 
-(cd dist && zip -r ../screenly-chrome-extension-0.3.zip *)
+(cd dist && zip -r ../screenly-chrome-extension-0.4.zip *)
 ```
 
 # Unit testing

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Now load the content of the `dist/` folder as an unpacked extension in Chrome. A
 # Distribute
 
 ```bash
+$ VERSION=0.4
+$ cat <<< $(cat src/manifest.json | jq --arg version "$VERSION" '.version = $version') > src/manifest.json
 $ docker compose build
 $ docker run \
     --rm -ti \

--- a/README.md
+++ b/README.md
@@ -13,17 +13,7 @@ Now load the content of the `dist/` folder as an unpacked extension in Chrome. A
 # Distribute
 
 ```bash
-$ VERSION=0.4
-$ cat <<< $(cat src/manifest.json | jq --arg version "$VERSION" '.version = $version') > src/manifest.json
-$ docker compose build
-$ docker run \
-    --rm -ti \
-    -v $(pwd):/app:delegated \
-    -v /app/node_modules \
-    sce_webpack:latest \
-    /bin/bash -c "npx webpack --config webpack.prod.js"
-
-(cd dist && zip -r ../screenly-chrome-extension-0.4.zip *)
+$ VERSION=<EXTENSION_VERSION> ./bin/package_extension.sh
 ```
 
 # Unit testing

--- a/bin/package_extension.sh
+++ b/bin/package_extension.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+VERSION=${VERSION:-0.0.0}
+cat <<< $(cat src/manifest.json | jq --arg version "$VERSION" '.version = $version') \
+    > src/manifest.json
+
+docker compose build
+docker run \
+    --rm -ti \
+    -v $(pwd):/app:delegated \
+    -v /app/node_modules \
+    sce_webpack:latest \
+    /bin/bash -c "npx webpack --config webpack.prod.js"
+
+git restore src/manifest.json
+
+(cd dist && zip -r ../screenly-chrome-extension-$VERSION.zip *)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Save to Screenly",
-  "version": "$SCREENLY_CE_VERSION",
+  "version": "1.0.1",
   "description": "Display live web pages on your Screenly digital sign.",
   "icons": {
     "16": "assets/images/screenly-logo-16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Save to Screenly",
-  "version": "1.2.0",
+  "version": "$SCREENLY_CE_VERSION",
   "description": "Display live web pages on your Screenly digital sign.",
   "icons": {
     "16": "assets/images/screenly-logo-16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Save to Screenly",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Display live web pages on your Screenly digital sign.",
   "icons": {
     "16": "assets/images/screenly-logo-16.png",


### PR DESCRIPTION
### Overview

* Fixes #31 
* Bumps extension version (in manifest file) from `1.0.1` to `1.2.0`.

### Screenshots

![image](https://github.com/user-attachments/assets/d0f66027-acf7-4c52-a003-b27386df9a62)
